### PR TITLE
fix: Ensure consistent textarea styling for UI stability

### DIFF
--- a/style.css
+++ b/style.css
@@ -89,11 +89,6 @@ textarea {
     min-height: 100px; /* Default for textareas like 'message' */
 }
 
-/* Specific styling for the phone number textarea */
-#phoneNumber {
-    min-height: 80px; /* Adjusted for ~3-4 lines of phone numbers */
-}
-
 button {
     width: 100%;
     padding: 12px;


### PR DESCRIPTION
This commit addresses potential UI inconsistencies by ensuring all textareas share the same styling rules, particularly for min-height.

- Removed a specific `min-height` override for the `#phoneNumber` textarea in `style.css`.
- Both `#phoneNumber` and `#message` textareas now consistently use the general `textarea` styling, which includes `min-height: 100px`.

This change aims to resolve any layout issues you reported and ensures a more uniform appearance for form elements. UI analysis confirmed the page remains responsive.